### PR TITLE
Update Smagorinsky.py

### DIFF
--- a/solvers/NSfracStep/LES/Smagorinsky.py
+++ b/solvers/NSfracStep/LES/Smagorinsky.py
@@ -18,9 +18,10 @@ def les_setup(u_, mesh, Smagorinsky, CG1Function, nut_krylov_solver, bcs, **NS_n
     CG1 = FunctionSpace(mesh, "CG", 1)
     
     # Compute cell size and put in delta
+    dim = mesh.geometry().dim()
     delta = Function(DG)
     delta.vector().zero()
-    delta.vector().axpy(1.0, assemble(TestFunction(DG)*dx))
+    delta.vector().set_local(assemble(TestFunction(DG)*dx).array()**(1./dim))
     delta.vector().apply('insert')
     
     # Set up Smagorinsky form


### PR DESCRIPTION
Delta was the volume (3D) / area (2D) of each cell and not the length scale, thus for small elements in 3D nu_t became close to zero.

The new implementation is 2-3 times as slow, but is still twice as fast as the previous implementation (tested with N=10 unit cube):

```python
delta = project(pow(CellVolume(mesh), 1./dim), DG)
```