### PR TITLE
Fixes for fenics 2018.1.0

### DIFF
--- a/oasis/NSCoupled.py
+++ b/oasis/NSCoupled.py
@@ -166,7 +166,7 @@ def iterate_scalar(iters=max_iter, errors=max_error):
                 scalar_hook(**globals())
                 scalar_solve(**globals())
                 err[ci] = b[ci].norm('l2')
-                if MPI.comm_world.Get_rank() == 0:
+                if MPI.rank(MPI.comm_world) == 0:
                     print('Iter {}, Error {} = {}'.format(citer, ci, err[ci]))
                 citer += 1
 

--- a/oasis/common/io.py
+++ b/oasis/common/io.py
@@ -21,7 +21,7 @@ def create_initial_folders(folder, restart_folder, sys_comp, tstep, info_red,
     """Create necessary folders."""
     info_red("Creating initial folders")
     # To avoid writing over old data create a new folder for each run
-    if MPI.comm_world.Get_rank() == 0:
+    if MPI.rank(MPI.comm_world) == 0:
         try:
             makedirs(folder)
         except OSError:
@@ -112,7 +112,7 @@ def save_tstep_solution_h5(tstep, q_, u_, newfolder, tstepfiles, constrained_dom
         for comp, tstepfile in six.iteritems(tstepfiles):
             tstepfile << (q_[comp], float(tstep))
 
-    if MPI.comm_world.Get_rank() == 0:
+    if MPI.rank(MPI.comm_world) == 0:
         if not path.exists(path.join(timefolder, "params.dat")):
             f = open(path.join(timefolder, 'params.dat'), 'wb')
             pickle.dump(NS_parameters,  f)
@@ -154,10 +154,10 @@ def save_checkpoint_solution_h5(tstep, q_, q_1, newfolder, u_components,
         if ui in u_components:
             newfile.write(q_1[ui].vector(), '/previous')
         if path.exists(oldfile):
-            if MPI.comm_world.Get_rank() == 0:
+            if MPI.rank(MPI.comm_world) == 0:
                 system('rm {0}'.format(oldfile))
         MPI.barrier(MPI.comm_world)
-    if MPI.comm_world.Get_rank() == 0 and path.exists(path.join(checkpointfolder, "params_old.dat")):
+    if MPI.rank(MPI.comm_world) == 0 and path.exists(path.join(checkpointfolder, "params_old.dat")):
         system('rm {0}'.format(path.join(checkpointfolder, "params_old.dat")))
 
 
@@ -168,7 +168,7 @@ def check_if_kill(folder):
         found = 1
     collective = MPI.sum(MPI.comm_world, found)
     if collective > 0:
-        if MPI.comm_world.Get_rank() == 0:
+        if MPI.rank(MPI.comm_world) == 0:
             remove(path.join(folder, 'killoasis'))
             info_red('killoasis Found! Stopping simulations cleanly...')
         return True
@@ -183,7 +183,7 @@ def check_if_reset_statistics(folder):
         found = 1
     collective = MPI.sum(MPI.comm_world, found)
     if collective > 0:
-        if MPI.comm_world.Get_rank() == 0:
+        if MPI.rank(MPI.comm_world) == 0:
             remove(path.join(folder, 'resetoasis'))
             info_red('resetoasis Found!')
         return True

--- a/oasis/problems/NSfracStep/Channel.py
+++ b/oasis/problems/NSfracStep/Channel.py
@@ -106,7 +106,7 @@ def body_force(nu, Re_tau, utau, **NS_namespace):
 def pre_solve_hook(V, u_, mesh, AssignedVectorFunction, newfolder, MPI,
                     Nx, Ny, Nz, Lx, Ly, Lz, **NS_namespace):
     """Called prior to time loop"""
-    if MPI.comm_world.Get_rank() == 0:
+    if MPI.rank(MPI.comm_world) == 0:
         makedirs(path.join(newfolder, "Stats"))
 
     uv = AssignedVectorFunction(u_)
@@ -138,7 +138,7 @@ def create_bcs(V, q_, q_1, q_2, sys_comp, u_components, Ly, **NS_namespace):
 
 
 class RandomStreamVector(Expression):
-    random.seed(2 + MPI.comm_world.Get_rank())
+    random.seed(2 + MPI.rank(MPI.comm_world))
 
     def eval(self, values, x):
         values[0] = 0.0005 * random.random()
@@ -197,7 +197,7 @@ def temporal_hook(q_, u_, V, tstep, uv, stats, update_statistics,
         u1 = assemble(dot(u_, normal) * ds(1, domain=mesh, subdomain_data=facets))
         normv = norm(q_['u1'].vector())
         normw = norm(q_['u2'].vector())
-        if MPI.comm_world.Get_rank() == 0:
+        if MPI.rank(MPI.comm_world) == 0:
             print("Flux = ", u1, " tstep = ", tstep, " norm = ", normv, normw)
 
 def theend(newfolder, tstep, stats, **NS_namespace):

--- a/oasis/problems/NSfracStep/DrivenCavity.py
+++ b/oasis/problems/NSfracStep/DrivenCavity.py
@@ -73,7 +73,7 @@ def theend_hook(u_, p_, uv, mesh, testing, **NS_namespace):
         plot(p_, title='Pressure')
 
     u_norm = norm(u_[0].vector())
-    if MPI.comm_world.Get_rank() == 0 and testing:
+    if MPI.rank(MPI.comm_world) == 0 and testing:
         print("Velocity norm = {0:2.6e}".format(u_norm))
 
     if not testing:

--- a/oasis/problems/NSfracStep/TaylorGreen2D.py
+++ b/oasis/problems/NSfracStep/TaylorGreen2D.py
@@ -125,7 +125,7 @@ def temporal_hook(q_, t, nu, VV, dt, plot_interval, initial_fields, tstep, sys_c
             error = norm(ue.vector()) / uen
             err[ui] = "{0:2.6e}".format(norm(ue.vector()) / uen)
             total_error[i] += error * dt
-        if MPI.comm_world.Get_rank() == 0:
+        if MPI.rank(MPI.comm_world) == 0:
             print("Error is ", err, " at time = ", t)
 
 
@@ -143,7 +143,7 @@ def theend_hook(mesh, q_, t, dt, nu, VV, sys_comp, total_error, initial_fields, 
         final_error[i] = errornorm(q_[ui], ue)
 
     hmin = mesh.hmin()
-    if MPI.comm_world.Get_rank() == 0:
+    if MPI.rank(MPI.comm_world) == 0:
         print("hmin = {}".format(hmin))
     s0 = "Total Error:"
     s1 = "Final Error:"
@@ -151,6 +151,6 @@ def theend_hook(mesh, q_, t, dt, nu, VV, sys_comp, total_error, initial_fields, 
         s0 += " {0:}={1:2.6e}".format(ui, total_error[i])
         s1 += " {0:}={1:2.6e}".format(ui, final_error[i])
 
-    if MPI.comm_world.Get_rank() == 0:
+    if MPI.rank(MPI.comm_world) == 0:
         print(s0)
         print(s1)

--- a/oasis/problems/__init__.py
+++ b/oasis/problems/__init__.py
@@ -71,17 +71,17 @@ GREEN = "\033[1;37;32m%s\033[0m"
 
 
 def info_blue(s, check=True):
-    if MPI.comm_world.Get_rank() == 0 and check:
+    if MPI.rank(MPI.comm_world) == 0 and check:
         print(BLUE % s)
 
 
 def info_green(s, check=True):
-    if MPI.comm_world.Get_rank() == 0 and check:
+    if MPI.rank(MPI.comm_world) == 0 and check:
         print(GREEN % s)
 
 
 def info_red(s, check=True):
-    if MPI.comm_world.Get_rank() == 0 and check:
+    if MPI.rank(MPI.comm_world) == 0 and check:
         print(RED % s)
 
 
@@ -102,7 +102,7 @@ class OasisMemoryUsage:
         self.prev_vm = self.memory_vm
         self.memory = MPI.sum(MPI.comm_world, getMemoryUsage())
         self.memory_vm = MPI.sum(MPI.comm_world, getMemoryUsage(False))
-        if MPI.comm_world.Get_rank() == 0 and verbose:
+        if MPI.rank(MPI.comm_world) == 0 and verbose:
             info_blue('{0:26s}  {1:10d} MB {2:10d} MB {3:10d} MB {4:10d} MB'.format(s,
                         int(self.memory - self.prev), int(self.memory),
                         int(self.memory_vm - self.prev_vm), int(self.memory_vm)))

--- a/oasis/solvers/NSCoupled/__init__.py
+++ b/oasis/solvers/NSCoupled/__init__.py
@@ -49,5 +49,5 @@ def get_solvers(**NS_namespace):
     return up_sol, c_sol
 
 def print_velocity_pressure_info(iter, error, **NS_namespace):
-    if MPI.comm_world.Get_rank() == 0:
+    if MPI.rank(MPI.comm_world) == 0:
         print("Iter {}, Error = {}".format(iter + 1, error))

--- a/oasis/solvers/NSCoupled/cylindrical.py
+++ b/oasis/solvers/NSCoupled/cylindrical.py
@@ -32,7 +32,7 @@ def setup(u_, p_, up_, up, u, p, v, q, nu, mesh, c, ct, q_,
     Fs = {"up": F}
     Ac = {}
     Js = {}
-    h = CellSize(mesh)
+    h = CellDiameter(mesh)
     vw = ct + h * inner(grad(ct), u_)
     n = FacetNormal(mesh)
     for ci in scalar_components:


### PR DESCRIPTION
This fixes some problems I had when trying to run Oasis with FEniCS 2018.1.0. Both CellSize() and MPI.com_world.Get_rank() seem to have been deprecated:

AttributeError: 'dolfin.cpp.MPICommWrapper' object has no attribute 'Get_rank'