### PR TITLE
Ensure that a unique problem module exists before importing

### DIFF
--- a/oasis/NSCoupled.py
+++ b/oasis/NSCoupled.py
@@ -25,15 +25,24 @@ problems/NSCoupled/__init__.py for all possible parameters.
 
 commandline_kwargs = parse_command_line()
 
+# Import the problem module
 default_problem = 'DrivenCavity'
-#exec('from problems.NSCoupled.{} import *'.format(commandline_kwargs.get('problem', default_problem)))
 problemname = commandline_kwargs.get('problem', default_problem)
-try:
-    problemmod = importlib.import_module('.'.join(('oasis.problems.NSCoupled', problemname)))
-except ImportError:
-    problemmod = importlib.import_module(problemname)
-except:
-    raise RuntimeError(problemname+' not found')
+# Check if problem module exists in example problems directory and/or current directory
+problemspec1 = importlib.util.find_spec('.'.join(('oasis.problems.NSCoupled', problemname)))
+problemspec2 = importlib.util.find_spec(problemname)
+if problemspec1 and problemspec2:
+    raise RuntimeError(problemname+" found in example problems directory AND current directory (ambiguous).")
+elif problemspec1:
+    problemspec = problemspec1
+    print("Found problem '"+problemname+"' in example problems directory.")
+elif problemspec2:
+    problemspec = problemspec2
+    print("Found problem '"+problemname+"' in current directory.")
+else:
+    raise RuntimeError("Problem '"+problemname+"' not found.")
+problemmod = importlib.util.module_from_spec(problemspec)
+problemspec.loader.exec_module(problemmod)
 
 vars().update(**vars(problemmod))
 

--- a/oasis/NSCoupled.py
+++ b/oasis/NSCoupled.py
@@ -25,22 +25,17 @@ problems/NSCoupled/__init__.py for all possible parameters.
 
 commandline_kwargs = parse_command_line()
 
-# Import the problem module
+# Find the problem module
 default_problem = 'DrivenCavity'
 problemname = commandline_kwargs.get('problem', default_problem)
-# Check if problem module exists in example problems directory and/or current directory
-problemspec1 = importlib.util.find_spec('.'.join(('oasis.problems.NSCoupled', problemname)))
-problemspec2 = importlib.util.find_spec(problemname)
-if problemspec1 and problemspec2:
-    raise RuntimeError(problemname+" found in example problems directory AND current directory (ambiguous).")
-elif problemspec1:
-    problemspec = problemspec1
-    print("Found problem '"+problemname+"' in example problems directory.")
-elif problemspec2:
-    problemspec = problemspec2
-    print("Found problem '"+problemname+"' in current directory.")
-else:
-    raise RuntimeError("Problem '"+problemname+"' not found.")
+problemspec = importlib.util.find_spec('.'.join(('oasis.problems.NSCoupled', problemname)))
+if problemspec is None:
+    problemspec = importlib.util.find_spec(problemname)
+if problemspec is None:
+    raise RuntimeError(problemname+' not found')
+
+# Import the problem module
+print('Importing problem module '+problemname+':\n'+problemspec.origin)
 problemmod = importlib.util.module_from_spec(problemspec)
 problemspec.loader.exec_module(problemmod)
 

--- a/oasis/NSfracStep.py
+++ b/oasis/NSfracStep.py
@@ -37,22 +37,17 @@ from oasis.common import *
 
 commandline_kwargs = parse_command_line()
 
-# Import the problem module
+# Find the problem module
 default_problem = 'DrivenCavity'
 problemname = commandline_kwargs.get('problem', default_problem)
-# Check if problem module exists in example problems directory and/or current directory
-problemspec1 = importlib.util.find_spec('.'.join(('oasis.problems.NSfracStep', problemname)))
-problemspec2 = importlib.util.find_spec(problemname)
-if problemspec1 and problemspec2:
-    raise RuntimeError(problemname+" found in example problems directory AND current directory (ambiguous).")
-elif problemspec1:
-    problemspec = problemspec1
-    print("Found problem '"+problemname+"' in example problems directory.")
-elif problemspec2:
-    problemspec = problemspec2
-    print("Found problem '"+problemname+"' in current directory.")
-else:
-    raise RuntimeError("Problem '"+problemname+"' not found.")
+problemspec = importlib.util.find_spec('.'.join(('oasis.problems.NSfracStep', problemname)))
+if problemspec is None:
+    problemspec = importlib.util.find_spec(problemname)
+if problemspec is None:
+    raise RuntimeError(problemname+' not found')
+
+# Import the problem module
+print('Importing problem module '+problemname+':\n'+problemspec.origin)
 problemmod = importlib.util.module_from_spec(problemspec)
 problemspec.loader.exec_module(problemmod)
 

--- a/oasis/NSfracStep.py
+++ b/oasis/NSfracStep.py
@@ -37,14 +37,24 @@ from oasis.common import *
 
 commandline_kwargs = parse_command_line()
 
+# Import the problem module
 default_problem = 'DrivenCavity'
 problemname = commandline_kwargs.get('problem', default_problem)
-try:
-    problemmod = importlib.import_module('.'.join(('oasis.problems.NSfracStep', problemname)))
-except ImportError:
-    problemmod = importlib.import_module(problemname)
-except:
-    raise RuntimeError(problemname+' not found')
+# Check if problem module exists in example problems directory and/or current directory
+problemspec1 = importlib.util.find_spec('.'.join(('oasis.problems.NSfracStep', problemname)))
+problemspec2 = importlib.util.find_spec(problemname)
+if problemspec1 and problemspec2:
+    raise RuntimeError(problemname+" found in example problems directory AND current directory (ambiguous).")
+elif problemspec1:
+    problemspec = problemspec1
+    print("Found problem '"+problemname+"' in example problems directory.")
+elif problemspec2:
+    problemspec = problemspec2
+    print("Found problem '"+problemname+"' in current directory.")
+else:
+    raise RuntimeError("Problem '"+problemname+"' not found.")
+problemmod = importlib.util.module_from_spec(problemspec)
+problemspec.loader.exec_module(problemmod)
 
 vars().update(**vars(problemmod))
 


### PR DESCRIPTION
This fixes unexpected behaviour that occurs if a problem module exists in more than one location or if a problem module throws an exception during import.

Previously, there were two things that could go wrong:

1. The problem module is defined in both the examples directory and the current directory in which case the user might be unaware that the example problem takes precedence over the one in the current directory.

2. If the module exists but raises an exception during import then that exception is caught and an attempt is made to import the module from the current directory instead. Further exceptions are then caught and a RuntimeError is raised which (misleadingly) informs the user that the module could not be found.

This made it difficult to debug example problems because exceptions raised during import were caught by the exception handler.

References:

- https://docs.python.org/3/library/importlib.html#checking-if-a-module-can-be-imported