### PR TITLE
Remove Python 2 support

### DIFF
--- a/oasis/common/__init__.py
+++ b/oasis/common/__init__.py
@@ -2,14 +2,13 @@ from .io import *
 from .utilities import *
 import sys
 import json
-import six
 
 def convert(input):
     if isinstance(input, dict):
         return {convert(key): convert(value) for key, value in input.iter()}
     elif isinstance(input, list):
         return [convert(element) for element in input]
-    elif isinstance(input, six.text_type):
+    elif isinstance(input, str):
         return input.encode('utf-8')
     else:
         return input

--- a/oasis/common/io.py
+++ b/oasis/common/io.py
@@ -5,7 +5,6 @@ __license__ = "GNU Lesser GPL version 3 or any later version"
 
 from os import makedirs, getcwd, listdir, remove, system, path
 import pickle
-import six
 from dolfin import (MPI, Function, XDMFFile, HDF5File,
     VectorFunctionSpace, FunctionAssigner)
 from oasis.problems import info_red
@@ -89,7 +88,7 @@ def save_tstep_solution_h5(tstep, q_, u_, newfolder, tstepfiles, constrained_dom
     timefolder = path.join(newfolder, 'Timeseries')
     if output_timeseries_as_vector:
         # project or store velocity to vector function space
-        for comp, tstepfile in six.iteritems(tstepfiles):
+        for comp, tstepfile in tstepfiles.items():
             if comp == "u":
                 # Create vector function and assigners
                 uv = AssignedVectorFunction(u_)
@@ -107,7 +106,7 @@ def save_tstep_solution_h5(tstep, q_, u_, newfolder, tstepfiles, constrained_dom
                 tstepfile.write(tstepfile.function, float(tstep))
 
     else:
-        for comp, tstepfile in six.iteritems(tstepfiles):
+        for comp, tstepfile in tstepfiles.items():
             tstepfile << (q_[comp], float(tstep))
 
     if MPI.rank(MPI.comm_world) == 0:

--- a/oasis/problems/__init__.py
+++ b/oasis/problems/__init__.py
@@ -8,7 +8,6 @@ import subprocess
 from os import getpid, path
 from collections import defaultdict
 from numpy import array, maximum, zeros
-import six
 
 # UnitSquareMesh(20, 20) # Just due to MPI bug on Scinet
 
@@ -202,7 +201,7 @@ def post_import_problem(NS_parameters, mesh, commandline_kwargs,
     """Called after importing from problem."""
 
     # Update NS_parameters with all parameters modified through command line
-    for key, val in six.iteritems(commandline_kwargs):
+    for key, val in commandline_kwargs.items():
         if isinstance(val, dict):
             NS_parameters[key].update(val)
         else:


### PR DESCRIPTION
I could not run Oasis inside a container because:

    ImportError: No module named six

Python 2 support was removed from FEniCS since 2018.1.0 and FEniCS docker images no longer include python-six. Since FEniCS no longer supports Python 2 we can also remove it from Oasis.



