### PR TITLE
Fix merging of xml files for Python >= 3.9

### DIFF
--- a/oasis/common/io.py
+++ b/oasis/common/io.py
@@ -268,14 +268,14 @@ def merge_xml_files(files):
     # Get last timestep of first tree
     base_tree = trees[indexes[0]]
     last_node = base_tree.getroot()[0][0][-1]
-    ind = 1 if len(last_node.getchildren()) == 3 else 2
+    ind = 1 if len(list(last_node)) == 3 else 2
     last_timestep = float(last_node[ind].attrib["Value"])
 
     # Append
     for index in indexes[1:]:
         tree = trees[index]
-        for node in tree.getroot()[0][0].getchildren():
-            ind = 1 if len(node.getchildren()) == 3 else 2
+        for node in list(tree.getroot()[0][0]):
+            ind = 1 if len(list(node)) == 3 else 2
             if last_timestep < float(node[ind].attrib["Value"]):
                 base_tree.getroot()[0][0].append(node)
                 last_timestep = float(node[ind].attrib["Value"])


### PR DESCRIPTION
The XML method `element.getchildren()` was removed in Python 3.9 and restarting a simulation therefore fails when running with recent versions of Python. According to the [documentation](https://docs.python.org/2/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren), one should use `list(element)` instead of `element.getchildren()`. This pull request fixes this problem.