### PR TITLE
remove old xdmf files from rank 0 only

### DIFF
--- a/oasis/common/io.py
+++ b/oasis/common/io.py
@@ -288,4 +288,5 @@ def merge_xml_files(files):
     base_tree.write(new_file[0], xml_declaration=True)
 
     # Delete xdmf file
-    [remove(f) for f in old_files]
+    if MPI.rank(MPI.comm_world) == 0:
+        [remove(f) for f in old_files]


### PR DESCRIPTION
Very minor point, but `remove` should be called from single rank only. 