### PR TITLE
Refactor memory usage and file downloads for improved portability

### DIFF
--- a/oasis/problems/Cylinder.py
+++ b/oasis/problems/Cylinder.py
@@ -6,14 +6,11 @@ __license__ = "GNU Lesser GPL version 3 or any later version"
 from dolfin import Mesh, AutoSubDomain, near
 import os
 import platform
+import urllib.request
 
 if not os.path.isfile("cylinder.xml"):
-    if platform.system() == "Linux":
-        os.system("wget -O cylinder.xml https://www.dropbox.com/s/d78g4cyjxl3ylay/cylinder.xml?dl=0")
-    elif platform.system() == "Darwin":
-        os.system("curl -L https://www.dropbox.com/s/d78g4cyjxl3ylay/cylinder.xml?dl=0 -o cylinder.xml")
-    else:
-        raise ImportError("Could not determine platform")
+    url = "https://www.dropbox.com/s/d78g4cyjxl3ylay/cylinder.xml?dl=1"
+    urllib.request.urlretrieve(url, "cylinder.xml")
 
     # try:
         #os.system("gmsh mesh/cylinder.geo -2 -o mesh/cylinder.msh")

--- a/oasis/problems/NSfracStep/EccentricStenosis.py
+++ b/oasis/problems/NSfracStep/EccentricStenosis.py
@@ -26,6 +26,7 @@ from oasis.problems import *
 import numpy as np
 import random
 import os
+import urllib.request
 import platform
 
 def problem_parameters(NS_parameters, NS_expressions, commandline_kwargs, **NS_namespace):
@@ -72,12 +73,8 @@ def problem_parameters(NS_parameters, NS_expressions, commandline_kwargs, **NS_n
 
 def mesh(mesh_file, **NS_namespace):
     if not os.path.isfile(mesh_file):
-        if platform.system() == "Linux":
-            os.system(f"wget -O {mesh_file} https://ndownloader.figshare.com/files/28254414")
-        elif platform.system() == "Darwin":
-            os.system(f"curl -L https://ndownloader.figshare.com/files/28254414 -o {mesh_file}")
-        else:
-            raise ImportError("Could not determine platform")
+        url = "https://ndownloader.figshare.com/files/28254414"
+        urllib.request.urlretrieve(url, mesh_file)
         print(f"Downloaded mesh {mesh_file}")
 
     mesh = Mesh(mesh_file)


### PR DESCRIPTION
This PR improves memory usage retrieval by preferring the `ps` command when available and falling back to Python's built-in `resource` module when necessary. Additionally, it replaces the use of `wget/curl` with `urllib.request`, eliminating OS-dependent system calls and ensuring a pure Python implementation for file downloads. These changes enhance portability and maintainability across Unix-based systems.